### PR TITLE
Implement sprint 1 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# OSAY
+# AuthEssay Beta
+
+This repository contains a minimal prototype for the AuthEssay service. The backend exposes
+an API endpoint that receives a report, generates follow up questions using GPT-4o and stores
+both the report and the generated questions in a database.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. Set your OpenAI API key in the environment:
+   ```bash
+   export OPENAI_API_KEY=your-key
+   ```
+3. Launch the API server:
+   ```bash
+   uvicorn app.main:app --reload --app-dir backend
+   ```
+4. Send a POST request to `/generate` with JSON body `{ "report_text": "..." }`.
+
+The server stores data in `backend/app.db` using SQLite for local development.

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,0 +1,18 @@
+from sqlalchemy.orm import Session
+from typing import List
+
+from . import models, schemas
+
+
+def create_report(db: Session, report: schemas.ReportCreate, questions: List[str]):
+    db_report = models.Report(text=report.text)
+    db.add(db_report)
+    db.commit()
+    db.refresh(db_report)
+
+    for q in questions:
+        db_question = models.Question(text=q, report_id=db_report.id)
+        db.add(db_question)
+    db.commit()
+    db.refresh(db_report)
+    return db_report

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,19 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI, Depends
+from sqlalchemy.orm import Session
+
+from . import models, schemas, crud
+from .database import engine, Base, get_db
+from .openai_client import generate_questions
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+@app.post("/generate", response_model=schemas.Report)
+def generate(report: schemas.GenerateRequest, db: Session = Depends(get_db)):
+    questions = generate_questions(report.report_text)
+    db_report = crud.create_report(db, schemas.ReportCreate(text=report.report_text), questions)
+    return db_report

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, Text, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
+
+from .database import Base
+
+
+class Report(Base):
+    __tablename__ = "reports"
+
+    id = Column(Integer, primary_key=True, index=True)
+    text = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    questions = relationship("Question", back_populates="report")
+
+
+class Question(Base):
+    __tablename__ = "questions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    report_id = Column(Integer, ForeignKey("reports.id"))
+    text = Column(Text, nullable=False)
+
+    report = relationship("Report", back_populates="questions")

--- a/backend/app/openai_client.py
+++ b/backend/app/openai_client.py
@@ -1,0 +1,23 @@
+import os
+from typing import List
+import openai
+
+# Requires OPENAI_API_KEY environment variable
+
+
+def generate_questions(report_text: str, n: int = 3) -> List[str]:
+    prompt = (
+        "次のレポート本文を読んで理解度を確認するための質問を" +
+        f"{n}問生成してください。\n" +
+        "レポート:\n" + report_text
+    )
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=256,
+    )
+    content = response["choices"][0]["message"]["content"]
+    # Assume each question separated by newline or numbered
+    questions = [q.strip() for q in content.splitlines() if q.strip()]
+    return questions[:n]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,39 @@
+from typing import List
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class QuestionBase(BaseModel):
+    text: str
+
+
+class QuestionCreate(QuestionBase):
+    pass
+
+
+class Question(QuestionBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ReportBase(BaseModel):
+    text: str
+
+
+class ReportCreate(ReportBase):
+    pass
+
+
+class Report(ReportBase):
+    id: int
+    created_at: datetime
+    questions: List[Question] = []
+
+    class Config:
+        orm_mode = True
+
+
+class GenerateRequest(BaseModel):
+    report_text: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+openai
+pydantic
+


### PR DESCRIPTION
## Summary
- set up FastAPI backend prototype for AuthEssay
- implement DB models for reports and questions
- add OpenAI client helper and CRUD logic
- expose `/generate` API to create questions from a report
- provide basic run instructions in README

## Testing
- `python -m py_compile backend/app/*.py`
- `pip install -r backend/requirements.txt`
- `uvicorn app.main:app --app-dir backend --port 8000` *(started server)*

------
https://chatgpt.com/codex/tasks/task_e_6843da01fdf483338b030dc2ec679f9a