### PR TITLE
Add demo mode for offline question generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ teachers.
    ```bash
    pip install -r backend/requirements.txt
    ```
-2. Set your OpenAI API key in the environment:
+2. (Optional) Set your OpenAI API key in the environment:
    ```bash
    export OPENAI_API_KEY=your-key
+   ```
+   To run the demo without calling the OpenAI API, set:
+   ```bash
+   export DEMO_MODE=1
    ```
 3. Launch the API server:
    ```bash

--- a/backend/app/openai_client.py
+++ b/backend/app/openai_client.py
@@ -2,10 +2,17 @@ import os
 from typing import List
 import openai
 
+DEMO_MODE = os.environ.get("DEMO_MODE") == "1"
+
 # Requires OPENAI_API_KEY environment variable
 
 
 def generate_questions(report_text: str, n: int = 3) -> List[str]:
+    """Return questions checking understanding of the report."""
+    if DEMO_MODE:
+        # In demo mode we skip the API call and just return sample questions
+        return [f"デモ質問{i+1}" for i in range(n)]
+
     prompt = (
         "次のレポート本文を読んで理解度を確認するための質問を" +
         f"{n}問生成してください。\n" +


### PR DESCRIPTION
## Summary
- support `DEMO_MODE` in `generate_questions`
- document demo mode usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68648f95a0a883338306e39579900ebf