### PR TITLE
Fix union type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ lets students submit reports, answer automatically generated questions and see
 their pass/fail result.  A simple dashboard API lists all submissions for
 teachers.
 
+For Japanese instructions on running the demo, see [README_JA.md](README_JA.md).
+
 
 ## Getting Started
 
@@ -12,9 +14,13 @@ teachers.
    ```bash
    pip install -r backend/requirements.txt
    ```
-2. Set your OpenAI API key in the environment:
+2. (Optional) Set your OpenAI API key in the environment:
    ```bash
    export OPENAI_API_KEY=your-key
+   ```
+   To run the demo without calling the OpenAI API, set:
+   ```bash
+   export DEMO_MODE=1
    ```
 3. Launch the API server:
    ```bash

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,34 @@
+# AuthEssay デモ版の利用方法
+
+このリポジトリには、学生のレポートを自動で評価するサービスのプロトタイプが含まれています。営業先でのデモ展示など、インターネット接続のない環境でも動作させられるよう、AI への問い合わせを行わずに定型の質問を返す **デモモード** を用意しています。
+
+## 前提条件
+- Python 3.11 以降
+- Node.js 20 以降
+
+## セットアップ手順
+
+1. 依存パッケージのインストール
+   ```bash
+   pip install -r backend/requirements.txt
+   cd frontend && npm install
+   ```
+2. 必要に応じて OpenAI の API キーを設定します（通常モードで動かす場合）。デモモードで動かす場合は `DEMO_MODE=1` を設定してください。
+   ```bash
+   export OPENAI_API_KEY=your-key      # 通常モードの場合
+   export DEMO_MODE=1                  # デモモードの場合
+   ```
+3. バックエンドの起動
+   ```bash
+   uvicorn app.main:app --reload --app-dir backend
+   ```
+4. フロントエンドのビルドと起動
+   ```bash
+   cd frontend
+   npm run build       # 一度だけ実行
+   npm start           # localhost:3000 でサービスが立ち上がります
+   ```
+
+ブラウザで `http://localhost:3000` にアクセスすると、ログイン画面が表示されます。ユーザー名を入力してログインし、レポートの投稿、質問への回答、採点結果の確認まで一連の流れを体験できます。教師用のダッシュボードは `/dashboard` で確認できます。
+
+保存されたデータは `backend/app.db` に SQLite 形式で格納されます。

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -48,7 +48,9 @@ def set_report_grade(db: Session, report_id: int, grade: str):
 def list_reports(db: Session):
     return db.query(models.Report).all()
 
-def create_report(db: Session, report: schemas.ReportCreate, questions: List[str]):
+# Deprecated: legacy API kept for backward compatibility
+def create_report_simple(db: Session, report: schemas.ReportCreate, questions: List[str]):
+    """Create a report without associating it with a student."""
     db_report = models.Report(text=report.text)
     db.add(db_report)
     db.commit()

--- a/backend/app/openai_client.py
+++ b/backend/app/openai_client.py
@@ -2,10 +2,17 @@ import os
 from typing import List
 import openai
 
+DEMO_MODE = os.environ.get("DEMO_MODE") == "1"
+
 # Requires OPENAI_API_KEY environment variable
 
 
 def generate_questions(report_text: str, n: int = 3) -> List[str]:
+    """Return questions checking understanding of the report."""
+    if DEMO_MODE:
+        # In demo mode we skip the API call and just return sample questions
+        return [f"デモ質問{i+1}" for i in range(n)]
+
     prompt = (
         "次のレポート本文を読んで理解度を確認するための質問を" +
         f"{n}問生成してください。\n" +

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from datetime import datetime
 from pydantic import BaseModel
 
@@ -37,7 +37,7 @@ class Report(ReportBase):
     id: int
     created_at: datetime
     questions: List[Question] = []
-    grade: str | None = None
+    grade: Optional[str] = None
 
 
     class Config:


### PR DESCRIPTION
## Summary
- tweak schema typing to avoid Python <3.10 errors
- keep demo instructions with DEMO_MODE in Japanese and English READMEs
- demo mode question generation skips OpenAI API calls
- resolve duplicate create_report definitions so backend works

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68648f95a0a883338306e39579900ebf